### PR TITLE
Make license/badge lookup base on URL path for easier referencing

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from flask import Flask, request, render_template
+from flask import Flask, render_template
 
 import dataset
 
@@ -11,50 +11,50 @@ app = Flask(__name__, static_folder="public", template_folder="views")
 ################################################################################
 # Licenses
 ################################################################################
+LICENSE_CONTEXT = {
+    "title": "Seattle Public Vehicle Lookup",
+    "entity_name_long": "license plate",
+    "entity_name_short": "License #",
+    "entity": "license",
+    "data_source": "https://data.seattle.gov/City-Business/Active-Fleet-Complement/enxu-fgzb",
+    "lookup_url": "license-lookup",
+}
+
+
 @app.route("/")
 def license_page():
     """Displays the homepage."""
-    context = {
-        "title": "Seattle Public Vehicle Lookup",
-        "entity_name_long": "license plate",
-        "entity_name_short": "License #",
-        "entity": "license",
-        "data_source": "https://data.seattle.gov/City-Business/Active-Fleet-Complement/enxu-fgzb",
-        "lookup_url": "license-lookup"
-    }
-    return render_template("index.html", **context)
+    return render_template("index.html", **LICENSE_CONTEXT)
 
 
-@app.route("/license-lookup", methods=["POST"])
-def license_lookup():
-    license = request.args.get("entity", "")
+@app.route("/license-lookup/<license>")
+def license_lookup(license):
     html = dataset.license_lookup(license)
-    # Return the list of remembered dreams.
-    return html
+    return render_template("index.html", **LICENSE_CONTEXT, entity_html=html)
 
 
 ################################################################################
 # Badges
 ################################################################################
+BADGE_CONTEXT = {
+    "title": "Seattle Officer Badge Lookup",
+    "entity_name_long": "badge number",
+    "entity_name_short": "Badge #",
+    "entity": "badge",
+    "data_source": "https://data.seattle.gov/City-Business/City-of-Seattle-Wage-Data/2khk-5ukd",
+    "lookup_url": "badge-lookup",
+}
+
+
 @app.route("/badge")
 def badge_page():
-    context = {
-        "title": "Seattle Officer Badge Lookup",
-        "entity_name_long": "badge number",
-        "entity_name_short": "Badge #",
-        "entity": "badge",
-        "data_source": "https://data.seattle.gov/City-Business/City-of-Seattle-Wage-Data/2khk-5ukd",
-        "lookup_url": "badge-lookup"
-    }
-    return render_template("index.html", **context)
+    return render_template("index.html", **BADGE_CONTEXT)
 
 
-@app.route("/badge-lookup", methods=["POST"])
-def badge_lookup():
-    badge = request.args.get("entity")
+@app.route("/badge-lookup/<badge>")
+def badge_lookup(badge):
     html = dataset.badge_lookup(badge)
-    # Return the list of remembered dreams.
-    return html
+    return render_template("index.html", **BADGE_CONTEXT, entity_html=html)
 
 
 if __name__ == "__main__":

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -32,9 +32,7 @@
         <button type="submit">Submit</button>
     </form>
     <section class="dreams">
-        <div id="{{ entity }}">
-
-        </div>
+        {{ entity_html | safe }}
     </section>
 </main>
 
@@ -55,12 +53,7 @@ $(function() {
   $('#main_form').submit(function(event) {
     event.preventDefault();
     var entity = $('input').val();
-    $.post('/{{ lookup_url }}?' + $.param({'entity': entity}), function(data) {
-      console.log('Data: ' + data);
-      $('#{{ entity }}').html(data);
-      $('input').val('');
-      $('input').focus();
-    });
+    window.location.replace("/{{lookup_url}}/" + entity)
   });
 
 });


### PR DESCRIPTION
Resolves #7

This makes it so that the entity lookup is done via URL rather than via form POST. The advantage of this is that people can share direct links to specific cars/officers, and also _less Javascript_.
