### PR TITLE
use API instead of in memory database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ dmypy.json
 .DS_Store
 
 *.swp
+
+.vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 gunicorn
 sodapy
+requests

--- a/src/app.py
+++ b/src/app.py
@@ -87,4 +87,5 @@ def name_lookup(name):
 
 
 if __name__ == "__main__":
+    dataset.ping_data_api()
     app.run()

--- a/src/app.py
+++ b/src/app.py
@@ -84,8 +84,3 @@ def badge_lookup(badge):
 def name_lookup(name):
     html = dataset.name_lookup(name, None, None)
     return render_template("index.html", **NAME_CONTEXT, entity_html=html)
-
-
-if __name__ == "__main__":
-    dataset.ping_data_api()
-    app.run()

--- a/src/app.py
+++ b/src/app.py
@@ -84,3 +84,7 @@ def badge_lookup(badge):
 def name_lookup(name):
     html = dataset.name_lookup(name, None, None)
     return render_template("index.html", **NAME_CONTEXT, entity_html=html)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -29,7 +29,7 @@ import requests
 client = Socrata("data.seattle.gov", None)
 LICENSE_DATASET = "enxu-fgzb"
 SALARY_DATASET = "2khk-5ukd"
-DATA_API_HOST = "https://spd-lookup.herokuapp.com"
+DATA_API_HOST = "https://1312api.tech-bloc-sea.dev"
 
 
 class RosterRecord(NamedTuple):
@@ -39,11 +39,6 @@ class RosterRecord(NamedTuple):
     last: str
     title: str
     unit: str
-
-
-def ping_data_api() -> int:
-    response = requests.Get(f"{DATA_API_HOST}/ping")
-    return response.status_code
 
 
 def _sort_names(records: List[Tuple]) -> Generator[RosterRecord, None, None]:

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -41,6 +41,11 @@ class RosterRecord(NamedTuple):
     unit: str
 
 
+def ping_data_api() -> int:
+    response = requests.Get(f"{DATA_API_HOST}/ping")
+    return response.status_code
+
+
 def _sort_names(records: List[Tuple]) -> Generator[RosterRecord, None, None]:
     # Convert to named tuples
     records = [RosterRecord(*r) for r in records]

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -5,6 +5,7 @@ from typing import Dict, Tuple, List, NamedTuple, Generator
 from flask import render_template
 from sodapy import Socrata
 import sqlite3
+import requests
 
 
 #################################################################################
@@ -28,7 +29,7 @@ import sqlite3
 client = Socrata("data.seattle.gov", None)
 LICENSE_DATASET = "enxu-fgzb"
 SALARY_DATASET = "2khk-5ukd"
-DATASET_PATH = Path(__file__).absolute().parent / "data" / "1-312-data.db"
+DATA_API_HOST = "https://spd-lookup.herokuapp.com"
 
 
 class RosterRecord(NamedTuple):
@@ -100,41 +101,40 @@ def _augment_with_salary(record: RosterRecord) -> Dict[str, str]:
     return context
 
 
-def _build_sql_query(queries: List[Tuple]) -> Tuple[str, List[str]]:
-    query_statements = []
-    parameters = []
-    for field, operator, value in queries:
-        if not value:
-            continue
-        query_statements.append(f"{field} {operator} ?")
-        parameters.append(value)
-    return " AND ".join(query_statements), parameters
-
-
 def name_lookup(first_name: str, last_name: str, badge: str) -> str:
     if not (first_name or last_name or badge):
         return ""
     else:
-        base_sql_query = "SELECT * FROM officers WHERE "
-        queries_list = [
-            ("First", "LIKE", first_name),
-            ("Last", "LIKE", last_name),
-            ("Serial", "=", badge),
-        ]
-        filter_sql_query, query_tuple = _build_sql_query(queries_list)
-        sql_query = base_sql_query + filter_sql_query
         try:
-            with sqlite3.connect(DATASET_PATH) as sql_conn:
-                sql_curs = sql_conn.cursor()
-                records = sql_curs.execute(sql_query, query_tuple,).fetchall()
-                if not records:
-                    html = "<p><b>No officer found for this name</b></p>"
-                else:
-                    htmls = []
-                    for r in _sort_names(records):
-                        context = _augment_with_salary(r)
-                        htmls.append(render_template("officer.j2", **context))
-                    html = "\n<br/>\n".join(htmls)
+            records = []
+            if not badge:
+                url = f"{DATA_API_HOST}/officer/search?first_name={first_name}&last_name={last_name}"
+            else:
+                url = f"{DATA_API_HOST}/officer?badge={badge}"
+            response = requests.get(url)
+
+            if response.status_code != 200:
+                raise Exception(
+                    f"unexpected status code {response.status_code} when accessing {url}"
+                )
+            records = response.json()
+            if len(records) == 0:
+                html = "<p><b>No officer found for this name</b></p>"
+            else:
+                htmls = []
+                for r in records:
+                    context = _augment_with_salary(
+                        RosterRecord(
+                            r.get("badge_number"),
+                            r.get("first_name"),
+                            r.get("middle_name"),
+                            r.get("last_name"),
+                            r.get("title"),
+                            r.get("unit"),
+                        )
+                    )
+                    htmls.append(render_template("officer.j2", **context))
+                html = "\n<br/>\n".join(htmls)
 
         except Exception as err:
             print(f"Error: {err}")


### PR DESCRIPTION
Opening a work in progress PR addressing #23 

Uses [API](https://github.com/barrytam20/spd-lookup) instead of in memory database for officer search.

Slightly changed search rules:
1. if badge is provided, do strict badge look up
2. instead of supporting wildcard search for names, does fuzzy search for name
    - if both first and last name are provided, fuzzy search for full name
    - else, fuzzy search for whatever is provided

I realize this is a pretty big change, so opening this as more of a request for comment than anything else. Also, I realize that this creates a dependency on my project. I am more than happy to transfer ownership of that project to this group