### PR TITLE
Escape name lookup for SODA client

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -90,7 +90,7 @@ def _augment_with_salary(record: RosterRecord) -> Dict[str, str]:
     results = client.get(
         SALARY_DATASET,
         limit=1,
-        where=f"last_name='{record.last}' AND first_name='{record.first}'",
+        where=f'last_name="{record.last}" AND first_name="{record.first}"',
     )
     if results:
         s = results[0]


### PR DESCRIPTION
It appears that looking up names via the SODA client needs to use double quotes (") to properly escape any special characters in the names themselves, e.g. single quotes ('). This change is a hot fix to resolve that.