### PR TITLE
Strict search checkbox

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -61,7 +61,7 @@ def name_page():
     last_name = request.args.get("last")
     badge = request.args.get("badge")
     strict_search = request.args.get("strict_search")
-    html = dataset.name_lookup(first_name, last_name, badge)
+    html = dataset.name_lookup(first_name, last_name, badge, strict_search)
 
     return render_template(
         "index.html",
@@ -76,38 +76,23 @@ def name_page():
 ################################################################################
 @app.route("/license-lookup/<license>")
 def license_lookup(license):
+    # LEGACY DO NOT TOUCH
     html = dataset.license_lookup(license)
-    strict_search = request.args.get("strict_search")
-    return render_template(
-        "index.html",
-        **LICENSE_CONTEXT,
-        entity_html=html,
-        strict_search=strict_search,
-    )
+    return render_template("index.html", **LICENSE_CONTEXT, entity_html=html)
 
 
 @app.route("/badge-lookup/<badge>")
 def badge_lookup(badge):
+    # LEGACY DO NOT TOUCH
     html = dataset.name_lookup(None, None, badge)
-    strict_search = request.args.get("strict_search")
-    return render_template(
-        "index.html",
-        **NAME_CONTEXT,
-        entity_html=html,
-        strict_search=strict_search,
-    )
+    return render_template("index.html", **NAME_CONTEXT, entity_html=html)
 
 
 @app.route("/name-lookup/<name>")
 def name_lookup(name):
+    # LEGACY DO NOT TOUCH
     html = dataset.name_lookup(name, None, None)
-    strict_search = request.args.get("strict_search")
-    return render_template(
-        "index.html",
-        **NAME_CONTEXT,
-        entity_html=html,
-        strict_search=strict_search,
-    )
+    return render_template("index.html", **NAME_CONTEXT, entity_html=html)
 
 
 if __name__ == "__main__":

--- a/src/app.py
+++ b/src/app.py
@@ -60,9 +60,15 @@ def name_page():
     first_name = request.args.get("first")
     last_name = request.args.get("last")
     badge = request.args.get("badge")
+    strict_search = request.args.get("strict_search")
     html = dataset.name_lookup(first_name, last_name, badge)
 
-    return render_template("index.html", **NAME_CONTEXT, entity_html=html)
+    return render_template(
+        "index.html",
+        **NAME_CONTEXT,
+        entity_html=html,
+        strict_search=strict_search,
+    )
 
 
 ################################################################################
@@ -71,19 +77,37 @@ def name_page():
 @app.route("/license-lookup/<license>")
 def license_lookup(license):
     html = dataset.license_lookup(license)
-    return render_template("index.html", **LICENSE_CONTEXT, entity_html=html)
+    strict_search = request.args.get("strict_search")
+    return render_template(
+        "index.html",
+        **LICENSE_CONTEXT,
+        entity_html=html,
+        strict_search=strict_search,
+    )
 
 
 @app.route("/badge-lookup/<badge>")
 def badge_lookup(badge):
     html = dataset.name_lookup(None, None, badge)
-    return render_template("index.html", **NAME_CONTEXT, entity_html=html)
+    strict_search = request.args.get("strict_search")
+    return render_template(
+        "index.html",
+        **NAME_CONTEXT,
+        entity_html=html,
+        strict_search=strict_search,
+    )
 
 
 @app.route("/name-lookup/<name>")
 def name_lookup(name):
     html = dataset.name_lookup(name, None, None)
-    return render_template("index.html", **NAME_CONTEXT, entity_html=html)
+    strict_search = request.args.get("strict_search")
+    return render_template(
+        "index.html",
+        **NAME_CONTEXT,
+        entity_html=html,
+        strict_search=strict_search,
+    )
 
 
 if __name__ == "__main__":

--- a/src/app.py
+++ b/src/app.py
@@ -64,10 +64,7 @@ def name_page():
     html = dataset.name_lookup(first_name, last_name, badge, strict_search)
 
     return render_template(
-        "index.html",
-        **NAME_CONTEXT,
-        entity_html=html,
-        strict_search=strict_search,
+        "index.html", **NAME_CONTEXT, entity_html=html, strict_search=strict_search,
     )
 
 

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -101,14 +101,18 @@ def _augment_with_salary(record: RosterRecord) -> Dict[str, str]:
     return context
 
 
-def name_lookup(first_name: str, last_name: str, badge: str) -> str:
+def name_lookup(
+    first_name: str, last_name: str, badge: str, strict_search: bool = False
+) -> str:
     if not (first_name or last_name or badge):
         return ""
     else:
         try:
-            records = []
             if not badge:
-                url = f"{DATA_API_HOST}/officer/search?first_name={first_name}&last_name={last_name}"
+                endpoint = f"{DATA_API_HOST}/officer"
+                if not strict_search:
+                    endpoint += "/search"
+                url = f"{endpoint}?first_name={first_name}&last_name={last_name}"
             else:
                 url = f"{DATA_API_HOST}/officer?badge={badge}"
             response = requests.get(url)

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -41,7 +41,7 @@ form {
   text-align: center;
 }
 
-input {
+.entity-input {
   display: block;
   margin-bottom: 10px;
   padding: 5px;

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -68,6 +68,10 @@ button:active {
   box-shadow: none;
 }
 
+label {
+  color: #666666;
+}
+
 li {
   margin-bottom: 5px;
 }

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -29,10 +29,12 @@
     <p>Wildcards can be used in specified fields. Use _ for single characters or % for multiple characters.</p>
     <p><i>E.g. ("Miss_ng" will find "Missing", "Miss%" will find "Missing")</i></p>
     <form action="/{{ lookup_url }}" method="GET">
+        {% if strict_search is defined %}
         <label>
             <input type="checkbox" id="strict_search" name="strict_search" value="strict_search" class="checkmark" {{ "checked" if strict_search else "" }}/>
             Enable strict searching
         </label>
+        {% endif %}
         {% for entity in entities %}
             <input id="{{ entity.query_param }}" class="entity-input" name="{{ entity.query_param }}" placeholder="{{ entity.entity_name_short }}" value="{{ request.args.get(entity.query_param, '') }}">
         {% endfor %}

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -29,6 +29,7 @@
     <p>Wildcards can be used in specified fields. Use _ for single characters or % for multiple characters.</p>
     <p><i>E.g. ("Miss_ng" will find "Missing", "Miss%" will find "Missing")</i></p>
     <form action="/{{ lookup_url }}" method="GET">
+        <label><input type="checkbox" id="fuzzy" name="fuzzy" class="checkmark" checked="true"/>Enable Fuzzy Search</label>
         {% for entity in entities %}
             <input id="{{ entity.query_param }}" class="entity-input" name="{{ entity.query_param }}" placeholder="{{ entity.entity_name_short }}">
         {% endfor %}

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -29,7 +29,10 @@
     <p>Wildcards can be used in specified fields. Use _ for single characters or % for multiple characters.</p>
     <p><i>E.g. ("Miss_ng" will find "Missing", "Miss%" will find "Missing")</i></p>
     <form action="/{{ lookup_url }}" method="GET">
-        <label><input type="checkbox" id="fuzzy" name="fuzzy" class="checkmark" checked="true"/>Enable Fuzzy Search</label>
+        <label>
+            <input type="checkbox" id="strict_search" name="strict_search" value="strict_search" class="checkmark" {{ "checked" if strict_search else "" }}/>
+            Enable strict searching
+        </label>
         {% for entity in entities %}
             <input id="{{ entity.query_param }}" class="entity-input" name="{{ entity.query_param }}" placeholder="{{ entity.entity_name_short }}">
         {% endfor %}

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -34,7 +34,7 @@
             Enable strict searching
         </label>
         {% for entity in entities %}
-            <input id="{{ entity.query_param }}" class="entity-input" name="{{ entity.query_param }}" placeholder="{{ entity.entity_name_short }}" value="{{ request.args.get(entity.query_param) }}">
+            <input id="{{ entity.query_param }}" class="entity-input" name="{{ entity.query_param }}" placeholder="{{ entity.entity_name_short }}" value="{{ request.args.get(entity.query_param, '') }}">
         {% endfor %}
         <button type="submit">Submit</button>
     </form>

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -34,7 +34,7 @@
             Enable strict searching
         </label>
         {% for entity in entities %}
-            <input id="{{ entity.query_param }}" class="entity-input" name="{{ entity.query_param }}" placeholder="{{ entity.entity_name_short }}">
+            <input id="{{ entity.query_param }}" class="entity-input" name="{{ entity.query_param }}" placeholder="{{ entity.entity_name_short }}" value="{{ request.args.get(entity.query_param) }}">
         {% endfor %}
         <button type="submit">Submit</button>
     </form>

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -30,7 +30,7 @@
     <p><i>E.g. ("Miss_ng" will find "Missing", "Miss%" will find "Missing")</i></p>
     <form action="/{{ lookup_url }}" method="GET">
         {% for entity in entities %}
-            <input id="{{ entity.query_param }}" name="{{ entity.query_param }}" placeholder="{{ entity.entity_name_short }}">
+            <input id="{{ entity.query_param }}" class="entity-input" name="{{ entity.query_param }}" placeholder="{{ entity.entity_name_short }}">
         {% endfor %}
         <button type="submit">Submit</button>
     </form>


### PR DESCRIPTION
Resolves #29

This PR adds a checkbox to enable strict searching by name on the officer page. The logic was done this way because an "enabled-by-default" checkbox was more difficult to implement (checkboxes don't appear in form arguments if they aren't checked).

The app now auto-populates the previous search into the input fields which makes concurrent searching easier.

I also put a warning on the legacy functions not to change them because...I thought I needed to and broke stuff lol.
