### PR TITLE
Fix officer field mismatches

### DIFF
--- a/src/dataset.py
+++ b/src/dataset.py
@@ -37,6 +37,7 @@ class RosterRecord(NamedTuple):
     last: str
     title: str
     unit: str
+    unit_description: str
 
 
 class Datasets:
@@ -88,6 +89,7 @@ def _augment_with_salary(record: RosterRecord) -> Dict[str, str]:
         "title": record.title,
         "unit": record.unit,
         "serial": record.serial,
+        "unit_description": record.unit_description,
     }
 
     results = client.get(
@@ -145,6 +147,7 @@ def name_lookup(
                             r.get("last_name"),
                             r.get("title"),
                             r.get("unit"),
+                            r.get("unit_description"),
                         )
                     )
                     htmls.append(render_template("officer_seattle.j2", **context))

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -28,7 +28,9 @@
     <p class="bold">{{ title }}</p>
     <p>Wildcards can be used in specified fields. Use _ for single characters or % for multiple characters.</p>
     <p><i>E.g. ("Miss_ng" will find "Missing", "Miss%" will find "Missing")</i></p>
-    <p><i><b>NOTE:</b> Badge lookup for the Tacoma dataset is not currently available, we will update the underlying data as soon as it is.</i></p>
+    {% if dataset_select is defined %}
+        <p><i><b>NOTE:</b> Badge lookup for the Tacoma dataset is not currently available, we will update the underlying data as soon as it is.</i></p>
+    {% endif %}
     <form action="/{{ lookup_url }}" method="GET">
         {% if dataset_select is defined %}
         <label for="dataset_select">Select a dataset:

--- a/src/views/officer_seattle.j2
+++ b/src/views/officer_seattle.j2
@@ -1,7 +1,8 @@
 <p><b>Badge #:</b> {{ serial }}</p>
 <p><b>Name:</b> {{ name }}</p>
 <p><b>Title Description*:</b> {{ title }}</p>
-<p><b>Unit Description*:</b> {{ unit }}</p>
+<p><b>Unit Description*:</b> {{ unit_description }}</p>
+<p><b>Unit*:</b> {{ unit }}</p>
 {% if job_title %}
 <p><b>Job Title:</b> {{ job_title }}</p>
 <p><b>Hourly Rate:</b> ${{ hourly_rate }}</p>


### PR DESCRIPTION
This PR fixes a bug where the officer return fields were not properly mapped to their HTML output. I've just gone ahead and added all the available columns to be returned and made sure they were all coming out in the right order.