### PR TITLE
Bugfix: Search on multiple fields

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -43,14 +43,15 @@ def get_results(
     values = []
     for query_param in query_params:
         value = kwargs.get(query_param)
+        if value is None:
+          continue
         values.append(value)
         params.append(f"{query_param}={value}")
     url += "&".join(params)
+    print(url)
 
-    if all(value is None for value in values):
+    if not values or all(value is None for value in values):
         return None
-
-    log.info(f"Querying URL: {url}")
 
     response = requests.get(url)
     if response.status_code != 200:

--- a/src/api.py
+++ b/src/api.py
@@ -44,7 +44,7 @@ def get_results(
     for query_param in query_params:
         value = kwargs.get(query_param)
         if value is None:
-          continue
+            continue
         values.append(value)
         params.append(f"{query_param}={value}")
     url += "&".join(params)

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -26,8 +26,12 @@
         </form>
     </div>
     <p class="bold">{{ title }}</p>
+    {% if dataset_select is not defined %}
     <p>Wildcards can be used in specified fields. Use _ for single characters or % for multiple characters.</p>
     <p><i>E.g. ("Miss_ng" will find "Missing", "Miss%" will find "Missing")</i></p>
+    {% else %}
+    <p><i><u>Note:</u> Strict searching must be checked for searches using non-fuzzy fields (e.g. Badge)</i></p>
+    {% endif %}
     <form action="/{{ lookup_url }}" method="GET">
         {% if dataset_select is defined %}
         <label for="dataset_select">Select a dataset:


### PR DESCRIPTION
We had two separate users report that last name searching was effectively broken. We found that the frontend was querying the API with empty form fields as `None` (e.g. a search on first name would add `last_name=None` to the query params). While this worked for first name searches, for some reason it failed on last name searches. This PR addresses the issue by skipping any `None` fields when composing the query params.

It also adds an additional warning for the user on badge fuzzy searching, which was already present in the UI. We should try to add some mechanism for badge to be searched through the fuzzy endpoint, even if it's a strict search under the hood - we get that complaint a lot.
