### PR TITLE
Show list of fuzzy fields as a note before the search form (fixes #46)

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -74,13 +74,14 @@ def get_query_fields(metadata: DatasetMetadata) -> List[Entity]:
     entities: List[Entity] = []
     for param in [*sorted(exact_params), *sorted(fuzzy_params)]:
         name = "Name Unknown"
+        fuzzy = False
         for field in fields:
             if param == field["FieldName"]:
                 name = field["Label"]
                 break
         if param in fuzzy_params:
-            name += " (fuzzy)"
-        entities.append({"entity_name": name, "query_param": param})
+            fuzzy = True
+        entities.append({"entity_name": name, "query_param": param, "fuzzy": fuzzy})
     return entities
 
 

--- a/src/api_types.py
+++ b/src/api_types.py
@@ -1,6 +1,7 @@
 import sys
 
 from typing import List, Dict
+
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
@@ -33,6 +34,7 @@ class Record(TypedDict, total=False):
 class Entity(TypedDict):
     entity_name: str
     query_param: str
+    fuzzy: bool
 
 
 DEFAULT_DATASET = "spd"

--- a/src/app.py
+++ b/src/app.py
@@ -24,7 +24,9 @@ def home():
 ################################################################################
 LICENSE_CONTEXT = {
     "title": "Seattle Public Vehicle Lookup",
-    "entities": [{"entity_name": "License (wildcard)", "query_param": "license"}],
+    "entities": [
+        {"entity_name": "License (wildcard)", "query_param": "license", "fuzzy": False}
+    ],
     "data_source": "https://data.seattle.gov/City-Business/Active-Fleet-Complement/enxu-fgzb",
     "lookup_url": "license",
 }

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -30,7 +30,16 @@
     <p>Wildcards can be used in specified fields. Use _ for single characters or % for multiple characters.</p>
     <p><i>E.g. ("Miss_ng" will find "Missing", "Miss%" will find "Missing")</i></p>
     {% else %}
-    <p><i><u>Note:</u> Strict searching must be checked for searches using non-fuzzy fields (e.g. Badge)</i></p>
+    <div class="field-note">
+        <p><i><u>Note:</u> Strict searching must be checked for these fields to use non-fuzzy matching:</i></p>
+        <ul>
+            {% for entity in entities %}
+                {% if entity.fuzzy %}
+                <li>{{entity.entity_name}}</li>
+                {% endif %}
+            {% endfor %}
+        </ul>
+    </div>
     {% endif %}
     <form action="/{{ lookup_url }}" method="GET">
         {% if dataset_select is defined %}


### PR DESCRIPTION
Fixes #46.

Shows a bulleted list of field names that will use 'strict' search when the 'enable strict searching' box is checked in lookup dialogs.

Adds a field to the Entity data container called 'fuzzy' (a boolean) for tracking which fields are fuzzy-able.