### PR TITLE
Prepare for historical data

### DIFF
--- a/src/extras.py
+++ b/src/extras.py
@@ -1,27 +1,37 @@
 from decimal import Decimal
-from typing import Dict, Callable
+from functools import lru_cache
+from typing import Dict, Callable, Optional
 
 from flask import render_template
 from soda_api import client, SALARY_DATASET
 from api_types import Record, DEFAULT_DATASET
 
 
-def _augment_with_salary(record: Record) -> str:
-    last = record["last_name"]
-    first = record["first_name"]
+@lru_cache(maxsize=1000)
+def _augment_with_salary_cached(
+    last: Optional[str], first: Optional[str]
+) -> Optional[str]:
+    """Cached augmentation for faster retrieval."""
     results = client.get(
         SALARY_DATASET,
         limit=1,
         where=f'last_name="{last}" AND first_name="{first}"',
     )
-    if results:
-        s = results[0]
-        projected = Decimal(s["hourly_rate"]) * 40 * 50
-        # Format with commas
-        context = {**s, "projected": f"{projected:,}"}
-        return render_template("seattle_extras.j2", **context)
+    if not results:
+        return ""
+    s = results[0]
+    projected = Decimal(s["hourly_rate"]) * 40 * 50
+    # Format with commas
+    context = {**s, "projected": f"{projected:,}"}
+    return render_template("seattle_extras.j2", **context)
+
+
+def augment_with_salary(record: Record) -> Optional[str]:
+    last = record["last_name"]
+    first = record["first_name"]
+    return _augment_with_salary_cached(last, first)
 
 
 EXTRAS_MAPPING: Dict[str, Callable[[Record], str]] = {
-    DEFAULT_DATASET: _augment_with_salary,
+    DEFAULT_DATASET: augment_with_salary,
 }

--- a/src/views/officer.j2
+++ b/src/views/officer.j2
@@ -7,4 +7,4 @@
     {% endif %}
 {% endfor %}
 {{ extras }}
-<p><i>*Record Source Roster Date: {{ metadata.last_available_roster_date }}</i></p>
+<p><i>*Most recent roster date available: {{ metadata.last_available_roster_date }}</i></p>

--- a/src/views/officer.j2
+++ b/src/views/officer.j2
@@ -1,5 +1,5 @@
 {% for field in metadata.fields %}
-{% set value = record.get(field.FieldName) %}
+{% set value = record.get(field.FieldName) | string %}
     {% if value and value.startswith("http") %}
     <p><b>{{ field.Label }}:</b> <a href="{{ value }}" target="_blank">{{ value }}</a></p>
     {% else %}


### PR DESCRIPTION
This PR adds two small changes to prepare for SeattleDSA/spd-lookup#23:
- Cache salary lookups to improve query performance for multiple rosters
- Cast all values to string before evaluating (this was failing on boolean values)
