### PR TITLE
List all strict fields and only show strict search when strict fields exist

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -82,7 +82,9 @@ def get_query_fields(metadata: DatasetMetadata) -> List[Entity]:
         if param in fuzzy_params:
             is_fuzzy = True
             name += " (fuzzy)"
-        entities.append({"entity_name": name, "query_param": param, "is_fuzzy": is_fuzzy})
+        entities.append(
+            {"entity_name": name, "query_param": param, "is_fuzzy": is_fuzzy}
+        )
     return entities
 
 

--- a/src/api.py
+++ b/src/api.py
@@ -78,11 +78,10 @@ def get_query_fields(metadata: DatasetMetadata) -> List[Entity]:
             if param == field["FieldName"]:
                 name = field["Label"]
                 break
+        is_fuzzy = False
         if param in fuzzy_params:
             is_fuzzy = True
             name += " (fuzzy)"
-        else:
-            is_fuzzy = False
         entities.append({"entity_name": name, "query_param": param, "is_fuzzy": is_fuzzy})
     return entities
 

--- a/src/api.py
+++ b/src/api.py
@@ -79,8 +79,11 @@ def get_query_fields(metadata: DatasetMetadata) -> List[Entity]:
                 name = field["Label"]
                 break
         if param in fuzzy_params:
+            is_fuzzy = True
             name += " (fuzzy)"
-        entities.append({"entity_name": name, "query_param": param})
+        else:
+            is_fuzzy = False
+        entities.append({"entity_name": name, "query_param": param, "is_fuzzy": is_fuzzy})
     return entities
 
 

--- a/src/api_types.py
+++ b/src/api_types.py
@@ -34,6 +34,7 @@ class Record(TypedDict, total=False):
 class Entity(TypedDict):
     entity_name: str
     query_param: str
+    is_fuzzy: bool
 
 
 DEFAULT_DATASET = "spd"

--- a/src/app.py
+++ b/src/app.py
@@ -75,11 +75,15 @@ def name_page():
         html = dataset.name_lookup(metadata, **request.args)
     entities = api.get_query_fields(metadata)
 
+    strict_entities = [entity for entity in entities if not entity["is_fuzzy"]]
+
     return render_template(
         "index.html",
         **NAME_CONTEXT,
         datasets=datasets.values(),
         entities=entities,
+        strict_entities=strict_entities,
+        allow_strict_search=len(strict_entities) != 0,
         entity_html=html,
         strict_search=strict_search,
         dataset_select=dataset_select,

--- a/src/app.py
+++ b/src/app.py
@@ -75,15 +75,12 @@ def name_page():
         html = dataset.name_lookup(metadata, **request.args)
     entities = api.get_query_fields(metadata)
 
-    strict_entities = [entity for entity in entities if not entity["is_fuzzy"]]
-
     return render_template(
         "index.html",
         **NAME_CONTEXT,
         datasets=datasets.values(),
         entities=entities,
-        strict_entities=strict_entities,
-        allow_strict_search=len(strict_entities) != 0,
+        strict_entities=[entity for entity in entities if not entity["is_fuzzy"]],
         entity_html=html,
         strict_search=strict_search,
         dataset_select=dataset_select,

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -29,8 +29,15 @@
     {% if dataset_select is not defined %}
     <p>Wildcards can be used in specified fields. Use _ for single characters or % for multiple characters.</p>
     <p><i>E.g. ("Miss_ng" will find "Missing", "Miss%" will find "Missing")</i></p>
-    {% else %}
-    <p><i><u>Note:</u> Strict searching must be checked for searches using non-fuzzy fields (e.g. Badge)</i></p>
+    {% elif allow_strict_search %}
+    <p>
+        <i>
+            <u>Note:</u>
+            Strict searching must be checked for searches using non-fuzzy fields
+            {# put this all on one line to avoid adding extra spaces :( #}
+            ({% for entity in strict_entities %}{{ entity.entity_name }}{% if not loop.last %}, {% else %}){% endif %}{% endfor %}
+        </i>
+    </p>
     {% endif %}
     <form action="/{{ lookup_url }}" method="GET">
         {% if dataset_select is defined %}
@@ -43,7 +50,7 @@
         </label>
         <br/>
         {% endif %}
-        {% if strict_search is defined %}
+        {% if allow_strict_search %}
         <label for="strict_search">
             <input
                 type="checkbox"

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -34,8 +34,11 @@
         <i>
             <u>Note:</u>
             Strict searching must be checked for searches using non-fuzzy fields
-            {# put this all on one line to avoid adding extra spaces :( #}
-            ({% for entity in strict_entities %}{{ entity.entity_name }}{% if not loop.last %}, {% else %}){% endif %}{% endfor %}
+            (
+            {%- for entity in strict_entities -%}
+                {{ entity.entity_name }}
+                {%- if not loop.last %}, {%- else %}){% endif %}
+            {% endfor -%}
         </i>
     </p>
     {% endif %}

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -29,7 +29,7 @@
     {% if dataset_select is not defined %}
     <p>Wildcards can be used in specified fields. Use _ for single characters or % for multiple characters.</p>
     <p><i>E.g. ("Miss_ng" will find "Missing", "Miss%" will find "Missing")</i></p>
-    {% elif allow_strict_search %}
+    {% elif strict_entities %}
     <p>
         <i>
             <u>Note:</u>
@@ -53,7 +53,7 @@
         </label>
         <br/>
         {% endif %}
-        {% if allow_strict_search %}
+        {% if strict_search is defined %}
         <label for="strict_search">
             <input
                 type="checkbox"


### PR DESCRIPTION
Testing instructions:
1. Go to the name page (`/name`)
2. Ensure that for each of the available PDs that the strict fields are listed when they are present.
3. Ensure that when there are no strict fields to show and that the strict search checkbox isn't present

Note: I'm unsure if the strict search checkbox should be hidden actually, but I'm guessing that if only fuzzy search fields are available then there's no strict search for that PD? If that's wrong it's easy to just revert that change