### PR TITLE
Default strict search to true if only strict fields are searched

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -64,7 +64,10 @@ def get_results(
     return records
 
 
-def get_query_fields(metadata: DatasetMetadata) -> List[Entity]:
+def get_query_fields(metadata: Optional[DatasetMetadata]) -> List[Entity]:
+    if metadata is None:
+        return []
+
     search_routes = metadata["search_routes"]
     fields = metadata["fields"]
     exact_params = set(search_routes["exact"]["query_params"])

--- a/src/app.py
+++ b/src/app.py
@@ -64,6 +64,7 @@ def name_page():
     dataset_select = params.pop("dataset_select", DEFAULT_DATASET)
     datasets = api.get_datasets()
     metadata = datasets.get(dataset_select, "")
+    entities = None
     if not metadata:
         # This shouldn't happen, but return *something* if the dataset is borked.
         html = f"<p><b>No data for dataset {dataset_select}</b></p>"
@@ -72,8 +73,11 @@ def name_page():
         # Don't call the backend API unless we have something.
         html = ""
     else:
-        html = dataset.name_lookup(metadata, **request.args)
-    entities = api.get_query_fields(metadata)
+        entities = api.get_query_fields(metadata)
+        html = dataset.name_lookup(metadata, entities, **request.args)
+
+    if entities is None:
+        entities = api.get_query_fields(metadata)
 
     return render_template(
         "index.html",

--- a/src/app.py
+++ b/src/app.py
@@ -60,11 +60,11 @@ def name_page():
     """Officer name lookup form render"""
     params = request.args.copy()
     # Pop the parameters we know will be present
-    strict_search = params.pop("strict_search", False)
+    strict_search = False
     dataset_select = params.pop("dataset_select", DEFAULT_DATASET)
     datasets = api.get_datasets()
     metadata = datasets.get(dataset_select, "")
-    entities = None
+    entities = api.get_query_fields(metadata)
     if not metadata:
         # This shouldn't happen, but return *something* if the dataset is borked.
         html = f"<p><b>No data for dataset {dataset_select}</b></p>"
@@ -73,11 +73,7 @@ def name_page():
         # Don't call the backend API unless we have something.
         html = ""
     else:
-        entities = api.get_query_fields(metadata)
-        html = dataset.name_lookup(metadata, entities, **request.args)
-
-    if entities is None:
-        entities = api.get_query_fields(metadata)
+        html, strict_search = dataset.name_lookup(metadata, entities, **request.args)
 
     return render_template(
         "index.html",

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 
 from flask import render_template
 
@@ -39,7 +40,7 @@ def license_lookup(license: str) -> str:
 
 def name_lookup(
     metadata: api_types.DatasetMetadata,
-    entities: list[api_types.Entity],
+    entities: typing.List[api_types.Entity],
     strict_search: bool = None,
     **kwargs,
 ) -> str:

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -39,9 +39,20 @@ def license_lookup(license: str) -> str:
 
 def name_lookup(
     metadata: api_types.DatasetMetadata,
-    strict_search: bool = False,
+    entities: list[api_types.Entity],
+    strict_search: bool = None,
     **kwargs,
 ) -> str:
+    if strict_search is None:
+        strict_search = True
+        for fuzzy_entity in [entity for entity in entities if entity["is_fuzzy"]]:
+            if (
+                fuzzy_entity["query_param"] in kwargs
+                and kwargs[fuzzy_entity["query_param"]] != ""
+            ):
+                strict_search = False
+                break
+
     try:
         records = api.get_results(metadata, strict_search, **kwargs)
         html = api.render_officers(records, metadata)

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -43,7 +43,7 @@ def name_lookup(
     entities: typing.List[api_types.Entity],
     strict_search: bool = None,
     **kwargs,
-) -> str:
+) -> typing.Tuple[str, bool]:
     if strict_search is None:
         strict_search = True
         for fuzzy_entity in [entity for entity in entities if entity["is_fuzzy"]]:
@@ -62,4 +62,4 @@ def name_lookup(
         html = f"<p><b>Error:</b> {err}"
 
     log.info("Final HTML:\n{}".format(html))
-    return html
+    return html, strict_search


### PR DESCRIPTION
Not sure if this is what was meant by #45 but took a shot at it.

There's probably a better way of making sure that `entities` is only retrieved one time than what I went with 🤔 