### PR TITLE
Add historical view for SPD

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -32,9 +32,13 @@ def get_datasets() -> DatasetMapping:
 
 
 def get_results(
-    metadata: DatasetMetadata, strict_search: bool, **kwargs
+    metadata: DatasetMetadata, strict_search: bool, historical: bool = False, **kwargs
 ) -> Optional[List[Record]]:
-    route_key = "exact" if strict_search else "fuzzy"
+    route_key = "fuzzy"
+    if historical:
+        route_key = "historical-exact"
+    elif strict_search:
+        route_key = "exact"
     route = metadata["search_routes"][route_key]
     search_path = route["path"]
     query_params = route["query_params"]
@@ -91,7 +95,9 @@ def get_query_fields(metadata: Optional[DatasetMetadata]) -> List[Entity]:
     return entities
 
 
-def render_officers(records: Optional[List[Record]], metadata: DatasetMetadata) -> str:
+def render_officers(
+    records: Optional[List[Record]], metadata: DatasetMetadata, historical: bool
+) -> str:
     if records is None:
         return ""
     if len(records) == 0:
@@ -107,6 +113,8 @@ def render_officers(records: Optional[List[Record]], metadata: DatasetMetadata) 
                 record=record,
                 metadata=metadata,
                 extras=extras,
+                historical_available=not historical
+                and "historical-exact" in metadata["search_routes"],
             )
         )
     html = "\n<br/>\n".join(htmls)

--- a/src/app.py
+++ b/src/app.py
@@ -88,6 +88,49 @@ def name_page():
 
 
 ################################################################################
+# Historical
+################################################################################
+HISTORICAL_CONTEXT = {
+    "title": "Historical Officer Name Lookup",
+    "entities": [
+        {
+            "entity_name": "Badge",
+            "query_param": "badge",
+        },
+    ],
+    "data_source": "https://data.seattle.gov/City-Business/City-of-Seattle-Wage-Data/2khk-5ukd",
+    "lookup_url": "historical-officers",
+}
+
+
+@app.route("/historical-officers")
+def historical_page():
+    """Historical officer name lookup form render"""
+    params = request.args.copy()
+    datasets = api.get_datasets()
+    metadata = datasets.get("spd", "")
+    if not metadata:
+        # This shouldn't happen, but return *something* if the dataset is borked.
+        html = "<p><b>No data for dataset historical SPD</b></p>"
+    elif all(val == "" for val in params.values()):
+        # If all parameters are emtpy, it was probably a dataset switch.
+        # Don't call the backend API unless we have something.
+        html = ""
+    else:
+        # throw away the strict_search value as historical search is always strict
+        html, _ = dataset.name_lookup(
+            metadata, entities=[], historical=True, **request.args
+        )
+
+    return render_template(
+        "index.html",
+        **HISTORICAL_CONTEXT,
+        datasets=datasets.values(),
+        entity_html=html,
+    )
+
+
+################################################################################
 # Old compatibility endpoints
 ################################################################################
 @app.route("/license-lookup/<license>")

--- a/src/app.py
+++ b/src/app.py
@@ -91,42 +91,29 @@ def name_page():
 # Historical
 ################################################################################
 HISTORICAL_CONTEXT = {
-    "title": "Historical Officer Name Lookup",
-    "entities": [
-        {
-            "entity_name": "Badge",
-            "query_param": "badge",
-        },
-    ],
     "data_source": "https://data.seattle.gov/City-Business/City-of-Seattle-Wage-Data/2khk-5ukd",
-    "lookup_url": "historical-officers",
 }
 
 
-@app.route("/historical-officers")
-def historical_page():
+@app.route("/historical-officers/<badge>")
+def historical_page(badge):
     """Historical officer name lookup form render"""
-    params = request.args.copy()
     datasets = api.get_datasets()
     metadata = datasets.get("spd", "")
     if not metadata:
         # This shouldn't happen, but return *something* if the dataset is borked.
         html = "<p><b>No data for dataset historical SPD</b></p>"
-    elif all(val == "" for val in params.values()):
-        # If all parameters are emtpy, it was probably a dataset switch.
-        # Don't call the backend API unless we have something.
-        html = ""
     else:
         # throw away the strict_search value as historical search is always strict
         html, _ = dataset.name_lookup(
-            metadata, entities=[], historical=True, **request.args
+            metadata, entities=[], historical=True, badge=badge
         )
 
     return render_template(
-        "index.html",
+        "historical.html",
         **HISTORICAL_CONTEXT,
-        datasets=datasets.values(),
         entity_html=html,
+        badge=badge,
     )
 
 

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -42,6 +42,7 @@ def name_lookup(
     metadata: api_types.DatasetMetadata,
     entities: typing.List[api_types.Entity],
     strict_search: bool = None,
+    historical: bool = False,
     **kwargs,
 ) -> typing.Tuple[str, bool]:
     if strict_search is None:
@@ -55,8 +56,8 @@ def name_lookup(
                 break
 
     try:
-        records = api.get_results(metadata, strict_search, **kwargs)
-        html = api.render_officers(records, metadata)
+        records = api.get_results(metadata, strict_search, historical, **kwargs)
+        html = api.render_officers(records, metadata, historical)
     except Exception as err:
         log.exception(err)
         html = f"<p><b>Error:</b> {err}"

--- a/src/views/base.html
+++ b/src/views/base.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+    <title>1-312-Hows-My-Driving</title>
+    <meta name="description" content="A cool thing made with Glitch">
+    <link id="favicon" rel="icon" href="/public/favicon.ico" type="image/x-icon">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/public/style.css">
+</head>
+<body>
+<header>
+    <h1>
+        1-312-Hows-My-Driving
+    </h1>
+</header>
+
+{% block content %}{% endblock %}
+
+<footer>
+    <a href="{{ data_source }}"><b>View the source data</b></a>
+    <br/>
+    <br/>
+    <a href="http://twitter.com/TechBlocSEA">If I break message TechBloc</a>
+</footer>
+
+</body>
+</html>

--- a/src/views/historical.html
+++ b/src/views/historical.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block content %}
+<main>
+	<h2>Historical view for badge #{{ badge }}</h2>
+	{{ entity_html | safe }}
+</main>
+{% endblock %}

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -1,21 +1,6 @@
-<!DOCTYPE html>
-<html lang="en-US">
-<head>
-    <title>1-312-Hows-My-Driving</title>
-    <meta name="description" content="A cool thing made with Glitch">
-    <link id="favicon" rel="icon" href="/public/favicon.ico" type="image/x-icon">
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/public/style.css">
-</head>
-<body>
-<header>
-    <h1>
-        1-312-Hows-My-Driving
-    </h1>
-</header>
+{% extends "base.html" %}
 
+{% block content %}
 <main>
     <div>
         <form action="/license" class="form_override">
@@ -23,9 +8,6 @@
         </form>
         <form action="/name" class="form_override">
             <button type="submit">Officers</button>
-        </form>
-        <form action="/historical-officers" class="form_override">
-            <button type="submit">Historical Officers</button>
         </form>
     </div>
     <p class="bold">{{ title }}</p>
@@ -84,13 +66,4 @@
         {{ entity_html | safe }}
     </section>
 </main>
-
-<footer>
-    <a href="{{ data_source }}"><b>View the source data</b></a>
-    <br/>
-    <br/>
-    <a href="http://twitter.com/TechBlocSEA">If I break message TechBloc</a>
-</footer>
-
-</body>
-</html>
+{% endblock %}

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -24,6 +24,9 @@
         <form action="/name" class="form_override">
             <button type="submit">Officers</button>
         </form>
+        <form action="/historical-officers" class="form_override">
+            <button type="submit">Historical Officers</button>
+        </form>
     </div>
     <p class="bold">{{ title }}</p>
     {% if dataset_select is not defined %}

--- a/src/views/officer.j2
+++ b/src/views/officer.j2
@@ -8,6 +8,6 @@
 {% endfor %}
 {{ extras }}
 {% if historical_available %}
-    <p>A historical view of this officer's records is <a href="/historical-officers?badge={{record.get('badge')}} ">available here</a>.</p>
+    <p>A historical view of this officer's records is <a href="/historical-officers/{{record.get('badge')}} ">available here</a>.</p>
 {% endif %}
 <p><i>*Most recent roster date available: {{ metadata.last_available_roster_date }}</i></p>

--- a/src/views/officer.j2
+++ b/src/views/officer.j2
@@ -7,4 +7,7 @@
     {% endif %}
 {% endfor %}
 {{ extras }}
+{% if historical_available %}
+    <p>A historical view of this officer's records is <a href="/historical-officers?badge={{record.get('badge')}} ">available here</a>.</p>
+{% endif %}
 <p><i>*Most recent roster date available: {{ metadata.last_available_roster_date }}</i></p>


### PR DESCRIPTION
Adds a historical search option as well as adds a link to each SPD officer's record to a historical view of their records.

Just took a stab at this, it definitely could use some polish and feedback. The button at the top obviously needs to change but will require refactoring a little bit of how the `form_override` class works.

Probably also some explanatory text would be a good idea to add to the `historical-officers` page.

Closes #51 