### PR TITLE
Ignore split name fields for historical table

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -119,6 +119,13 @@ def render_officers(records: Optional[List[Record]], metadata: DatasetMetadata) 
     return html
 
 
+FIELDS_NOT_TO_RENDER = {
+    "first_name",
+    "middle_name",
+    "last_name",
+}
+
+
 def render_historical_officers(
     records: Optional[List[Record]], metadata: DatasetMetadata
 ) -> str:
@@ -130,5 +137,9 @@ def render_historical_officers(
     return render_template(
         "officer-table.j2",
         records=records,
-        metadata=metadata,
+        fields=[
+            field
+            for field in metadata["fields"]
+            if field["FieldName"] not in FIELDS_NOT_TO_RENDER
+        ],
     )

--- a/src/views/officer-table.j2
+++ b/src/views/officer-table.j2
@@ -1,7 +1,7 @@
 <table>
     <thead>
         <tr>
-            {% for field in metadata.fields %}
+            {% for field in fields %}
                 <th>{{ field.Label }}</th>
             {% endfor %}
         </tr>
@@ -12,7 +12,7 @@
             {# records are ordered by date, starting with the present into the past, so the "previous" record will be the next item in the list of records #}
             {% set previous_record = loop.nextitem %}
             <tr>
-                {% for field in metadata.fields %}
+                {% for field in fields %}
                     <td class="{{ record | diff_classname(previous_record, field) }}">
                         {% set value = record.get(field.FieldName) | string %}
                         {% if value and value.startswith("http") %}


### PR DESCRIPTION
Skips the split name fields for the historical view in order to make the table a little (actually significantly) smaller.

<img width="1756" alt="Captura de Tela 2021-06-15 às 17 09 59" src="https://user-images.githubusercontent.com/24264157/122138887-86166780-cdfc-11eb-8e58-d9171c9d1ca0.png">

Should we also skip badge?