### PR TITLE
Only make SODA salary call if record is current

### DIFF
--- a/src/api_types.py
+++ b/src/api_types.py
@@ -29,6 +29,7 @@ class DatasetMetadata(TypedDict):
 class Record(TypedDict, total=False):
     first_name: str
     last_name: str
+    is_current: bool
 
 
 class Entity(TypedDict):

--- a/src/extras.py
+++ b/src/extras.py
@@ -25,6 +25,9 @@ def _augment_with_salary_cached(last: Optional[str], first: Optional[str]) -> st
 
 
 def augment_with_salary(record: Record) -> str:
+    if not record["is_current"]:
+        return ""
+
     last = record["last_name"]
     first = record["first_name"]
     return _augment_with_salary_cached(last, first)


### PR DESCRIPTION
Not sure if this is really all that's necessary. There's no noticable change in the UI because I think non-current records must have already been returning nothing from the SODA call and causing https://github.com/SeattleDSA/1-312-hows-my-driving/blob/71bfd209e142054917df63cd16a3bfd2f41a0fba/src/extras.py#L18-L19 to return `""`

Closes #48 