### PR TITLE
Add steps to disable AirPlay receiver on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Licenses are looked up in the dataset and if a vehicle is found, that data is di
 
 Build the image with `docker build -t <tag> .`. Run it with `docker run -p 5000:5000 <tag>`.
 
+NOTE: If you are running this on an Apple machine, it is possible that TCP port 500 will be "in use" by the MacOS Control Center app, which is using it to listen for AirPlay. You can disable this by performing the following:
+1. Open System Preferences>Sharing
+2. Uncheck "AirPlay Receiver"
+
+Alternatively you can use a different port if desired.
+
 ### If you want to make changes
 
 1. Install a python virtual environment: `python3 -m venv venv`


### PR DESCRIPTION
MacOS uses port 5000 to listen as an AirPlay Receiver. This overlaps the port we generally use for testing. Adding steps to disable this service.