### PR TITLE
Publish docker image to ghcr.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Docker image
 on:
   release:
     types: [published]
-  pull_request:
+  push:
     branches:
       - ci/*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
           registry: https://ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build container image
+      - name: Build and push image
         uses: docker/build-push-action@v2
         with:
           push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,8 @@ on:
   release:
     types: [published]
   pull_request:
-#    branches:
-#      - ci/*
+    branches:
+      - ci/*
 
 env:
   image_name: orcacollective/1-312-hows-my-driving

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ghcr.io/orcacollective/1-312-hows-my-driving:${{ github.sha }}
+            ghcr.io/orcacollective/1-312-hows-my-driving:${{ github.ref_name }}
+            ghcr.io/orcacollective/parler-data-searcher:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,12 @@ name: Publish Docker image
 on:
   release:
     types: [published]
+  pull_request:
+#    branches:
+#      - ci/*
 
+env:
+  image_name: orcacollective/1-312-hows-my-driving
 
 jobs:
   push_to_registry:
@@ -26,6 +31,6 @@ jobs:
         with:
           push: true
           tags: |
-            ghcr.io/orcacollective/1-312-hows-my-driving:${{ github.sha }}
-            ghcr.io/orcacollective/1-312-hows-my-driving:${{ github.ref_name }}
-            ghcr.io/orcacollective/1-312-hows-my-driving:latest
+            ghcr.io/${{ env.image_name }}:${{ github.sha }}
+            ghcr.io/${{ env.image_name }}:${{ github.ref_name }}
+            ghcr.io/${{ env.image_name }}:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
   push:
     branches:
-      - ci/*
+      - ci-*
 
 env:
   image_name: orcacollective/1-312-hows-my-driving

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,4 @@ jobs:
           tags: |
             ghcr.io/orcacollective/1-312-hows-my-driving:${{ github.sha }}
             ghcr.io/orcacollective/1-312-hows-my-driving:${{ github.ref_name }}
-            ghcr.io/orcacollective/parler-data-searcher:latest
+            ghcr.io/orcacollective/1-312-hows-my-driving:latest

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Build the image with `just build` and run it using `just up`.
 The server will be available at port `3030`.
 
 To run this image in production, use the `IS_PROD` variable for any actions, e.g. `IS_PROD=true just up`.
+By default, the production docker-compose file will pull the `latest` docker image.
+This can be overridden with the `DOCKER_TAG` environment variable.
 
 ### If you want to make changes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
     app:
         restart: always
-        build: .
+        image: ghcr.io/orcacollective/1-312-hows-my-driving:${DOCKER_TAG:-latest}
         environment:
             FLASK_APP: app
             FLASK_ENV: production

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 IS_PROD := env_var_or_default("IS_PROD", "")
-COMPOSE_FILE := "-f docker-compose.yml " + if IS_PROD == "true" {""} else {"-f docker-compose.override.yml "}
-DC := "docker-compose " + COMPOSE_FILE
+COMPOSE_FILE := " -f docker-compose.yml" + if IS_PROD == "true" {""} else {" -f docker-compose.override.yml"}
+DC := "docker-compose" + COMPOSE_FILE
 RUN := DC + " run --rm app"
 set dotenv-load := false
 
@@ -31,6 +31,16 @@ logs service="":
 # Run a command using the web image
 run +args:
 	{{ RUN }} {{ args }}
+
+# Pull the docker image
+pull:
+    {{ DC }} pull
+
+# Pull, build, and deploy all services
+deploy:
+    -git pull
+    @just pull
+    @just up
 
 # Run the static checks
 lint:


### PR DESCRIPTION
This PR adds a workflow and some `just` recipes for publishing the docker image to ghcr.io and deploying the image in production.
