### PR TITLE
Fix City of Seattle hourly rate conversion

### DIFF
--- a/src/extras.py
+++ b/src/extras.py
@@ -41,8 +41,8 @@ def _augment_with_salary_cached(last: Optional[str], first: Optional[str]) -> st
     # City of Seattle wage data formats rate as "$    <number>" for some
     # horrible reason, so we clean this data a bit for decimal conversion.
     if isinstance(hourly_rate, str):
-        hourly_rate = hourly_rate.replace("$", "").replace(" ", "")
-    s["hourly_rate"] = hourly_rate
+        hourly_rate = hourly_rate.strip("$ ")
+        s["hourly_rate"] = hourly_rate
     projected = Decimal(hourly_rate) * 40 * 50
     # Format with commas
     context = {**s, "projected": f"{projected:,}"}

--- a/src/extras.py
+++ b/src/extras.py
@@ -37,7 +37,13 @@ def _augment_with_salary_cached(last: Optional[str], first: Optional[str]) -> st
     if not results:
         return ""
     s = results[0]
-    projected = Decimal(s["hourly_rate"]) * 40 * 50
+    hourly_rate = s["hourly_rate"]
+    # City of Seattle wage data formats rate as "$    <number>" for some
+    # horrible reason, so we clean this data a bit for decimal conversion.
+    if isinstance(hourly_rate, str):
+        hourly_rate = hourly_rate.replace("$", "").replace(" ", "")
+    s["hourly_rate"] = hourly_rate
+    projected = Decimal(hourly_rate) * 40 * 50
     # Format with commas
     context = {**s, "projected": f"{projected:,}"}
     return render_template("extras/seattle-salary.html", **context)


### PR DESCRIPTION
City of Seattle wage data changed their wage data field from a float to a string...just to screw with us I bet :roll_eyes:. This PR performs some data cleaning if the `hourly_rate` is a string so that the conversion to a decimal value succeeds.

Values coming from the wage data looked like this: `$   91.42`
We need the values to look like this for decimal conversion: `91.42`
