### PR TITLE
Add image smoke test, github actions dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,10 @@ updates:
     labels:
       - "dependency"
       - "docker/env"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependency"
+      - "github-actions"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Start server
         run: just up
       - name: Check server
-        run: curl --fail -LI localhost:3030 -o /dev/null -w '%{http_code}\n'
+        run: |
+          # Wait for the server to be ready
+          sleep 5
+          curl --fail -LI localhost:3030 -o /dev/null -w '%{http_code}\n'
       - name: Stop server
         if: always()
         run: just down

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,3 +16,19 @@ jobs:
         run: pip install -r requirements-dev.txt
       - name: Run pre-commit checks
         run: pre-commit run --all-files
+
+  smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: extractions/setup-just@v1
+      - name: Build image
+        run: just build
+      - name: Start server
+        run: just up
+      - name: Check server
+        run: curl --fail -LI localhost:3030 -o /dev/null -w '%{http_code}\n'
+      - name: Stop server
+        if: always()
+        run: just down

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,6 +32,9 @@ jobs:
           # Wait for the server to be ready
           sleep 5
           curl --fail -LI localhost:3030 -o /dev/null -w '%{http_code}\n'
+      - name: Output logs
+        if: failure()
+        run: just logs
       - name: Stop server
         if: always()
         run: just down


### PR DESCRIPTION
This PR adds a simple smoke test to the CI/CD which builds the docker image, runs it, then attempts to curl the home page. This will provide a simple mechanism for determining if the dependencies work.

Follow up to #80 which also includes a dependabot change to include github actions.
